### PR TITLE
Adopt to enforcer 1.4. Used getMessage() instead of field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <api.version>1.1.1</api.version>
+        <api.version>1.4</api.version>
         <maven.version>2.0.9</maven.version>
     </properties>
 

--- a/src/main/java/org/apache/maven/plugins/enforcer/RequireDepMgt.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequireDepMgt.java
@@ -98,7 +98,7 @@ public class RequireDepMgt extends AbstractStandardEnforcerRule {
 
         if (sb.length() != 0) {
             throw new EnforcerRuleException(sb.toString() +
-                    (message == null ? "Please update the dependency management." : message));
+                    (getMessage() == null ? "Please update the dependency management." : getMessage()));
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/enforcer/RequireFilesContent.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequireFilesContent.java
@@ -72,7 +72,7 @@ public class RequireFilesContent extends AbstractStandardEnforcerRule {
 
         if (sb.length() != 0) {
             throw new EnforcerRuleException(sb.toString() +
-                    (message != null ? message :
+                    (getMessage() != null ? getMessage() :
                             "Some files produce errors, please check the error message for the individual file above."));
         }
     }


### PR DESCRIPTION
Somewhere between enforcer 1.1.1 and 1.4 field message become private. 
This PR allow to fix run-time problems with using this rules with enforcer 1.4

Issue was

INFO] Final Memory: 140M/2419M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4:enforce (distribution-management-used) on project codenvy-api-project: Execution distribution-management-used of goal org.apache.maven.plugins:maven-enforcer-plugin:1.4:enforce failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-enforcer-plugin:1.4:enforce: java.lang.IllegalAccessError: tried to access field org.apache.maven.plugins.enforcer.AbstractStandardEnforcerRule.message from class org.apache.maven.plugins.enforcer.RequireDepMgt
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-enforcer-plugin:1.4
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/sj/.m2/repository/org/apache/maven/plugins/maven-enforcer-plugin/1.4/maven-enforcer-plugin-1.4.jar
[ERROR] urls[1] = file:/home/sj/.m2/repository/com/ceilfors/maven/plugin/enforcer-rules/1.1.0/enforcer-rules-1.1.0.jar
[ERROR] urls[2] = file:/home/sj/.m2/repository/com/google/guava/guava/14.0.1/guava-14.0.1.jar
[ERROR] urls[3] = file:/home/sj/.m2/repository/org/codehaus/mojo/animal-sniffer-enforcer-rule/1.11/animal-sniffer-enforcer-rule-1.11.jar
[ERROR] urls[4] = file:/home/sj/.m2/repository/org/codehaus/mojo/animal-sniffer/1.11/animal-sniffer-1.11.jar
[ERROR] urls[5] = file:/home/sj/.m2/repository/org/ow2/asm/asm-all/4.0/asm-all-4.0.jar
[ERROR] urls[6] = file:/home/sj/.m2/repository/org/codehaus/mojo/extra-enforcer-rules/1.0-beta-2/extra-enforcer-rules-1.0-beta-2.jar
[ERROR] urls[7] = file:/home/sj/.m2/repository/org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.jar
[ERROR] urls[8] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
[ERROR] urls[9] = file:/home/sj/.m2/repository/org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.jar
[ERROR] urls[10] = file:/home/sj/.m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.4/maven-common-artifact-filters-1.4.jar
[ERROR] urls[11] = file:/home/sj/.m2/repository/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar
[ERROR] urls[12] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.jar
[ERROR] urls[13] = file:/home/sj/.m2/repository/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.jar
[ERROR] urls[14] = file:/home/sj/.m2/repository/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.jar
[ERROR] urls[15] = file:/home/sj/.m2/repository/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.jar
[ERROR] urls[16] = file:/home/sj/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.2.1/maven-reporting-api-2.2.1.jar
[ERROR] urls[17] = file:/home/sj/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.1/doxia-sink-api-1.1.jar
[ERROR] urls[18] = file:/home/sj/.m2/repository/org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.jar
[ERROR] urls[19] = file:/home/sj/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar
[ERROR] urls[20] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar
[ERROR] urls[21] = file:/home/sj/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[22] = file:/home/sj/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[23] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.jar
[ERROR] urls[24] = file:/home/sj/.m2/repository/commons-lang/commons-lang/2.3/commons-lang-2.3.jar
[ERROR] urls[25] = file:/home/sj/.m2/repository/org/apache/maven/enforcer/enforcer-api/1.4/enforcer-api-1.4.jar
[ERROR] urls[26] = file:/home/sj/.m2/repository/org/apache/maven/enforcer/enforcer-rules/1.4/enforcer-rules-1.4.jar
[ERROR] urls[27] = file:/home/sj/.m2/repository/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar
[ERROR] urls[28] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-i18n/1.0-beta-6/plexus-i18n-1.0-beta-6.jar
[ERROR] urls[29] = file:/home/sj/.m2/repository/org/apache/maven/plugin-testing/maven-plugin-testing-harness/1.3/maven-plugin-testing-harness-1.3.jar
[ERROR] urls[30] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-archiver/2.2/plexus-archiver-2.2.jar
[ERROR] urls[31] = file:/home/sj/.m2/repository/org/codehaus/plexus/plexus-io/2.0.4/plexus-io-2.0.4.jar
[ERROR] urls[32] = file:/home/sj/.m2/repository/junit/junit/4.11/junit-4.11.jar
[ERROR] urls[33] = file:/home/sj/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[project>com.codenvy.platform-api:codenvy-platform-api-parent:0.33.0-SNAPSHOT, parent: ClassRealm[maven.api, parent: null]]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] -> [Help 1]
